### PR TITLE
Parse warnings as well as errors from validator

### DIFF
--- a/flycheck-glsl.el
+++ b/flycheck-glsl.el
@@ -46,7 +46,8 @@
   See URL https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/"
   :command ("glslangValidator" source)
   :error-patterns
-  ((error line-start "ERROR: " column ":" line ": " (message) line-end))
+  ((error line-start "ERROR: " column ":" line ": " (message) line-end)
+   (warning line-start "WARNING: " column ":" line ": " (message) line-end))
   :modes glsl-mode)
 
 (add-to-list 'flycheck-checkers 'glsl-lang-validator)


### PR DESCRIPTION
Thanks for the mode - very helpful. This is just a change to parse the warnings as well as the errors from glslangValidator.
